### PR TITLE
Fix #64: Omit empty steps and errors from wide event logs

### DIFF
--- a/log/event.go
+++ b/log/event.go
@@ -175,9 +175,15 @@ func (e *Event) toAttrs(additionalReservedAttrKeys []string) []slog.Attr {
 		slog.String("name", e.name),
 		slog.Time("timestamp", e.timestamp),
 		slog.Duration("duration", e.duration),
-		slog.Any("steps", steps),
-		slog.Any("errors", eventErrors),
 	)
+
+	if len(steps) > 0 {
+		attrs = append(attrs, slog.Any("steps", steps))
+	}
+
+	if len(eventErrors) > 0 {
+		attrs = append(attrs, slog.Any("errors", eventErrors))
+	}
 
 	reservedSet := make(map[string]struct{}, len(reservedAttrKeys))
 	for _, k := range reservedAttrKeys {


### PR DESCRIPTION
## Summary

Closes #64

Modifies the wide event logging to omit `steps` and `errors` fields when they are empty arrays, reducing log noise and improving readability.

### Before
```json
{"level":"DEBUG","name":"http.request","timestamp":"2026-03-01T19:38:32.602385+03:00","duration":195040541,"steps":[],"errors":[],"request.remoteAddr":"127.0.0.1:60449","tokens.type":"bearer","request.method":"GET","request.status":301,"serviceName":"http server"}
```

### After
```json
{"level":"DEBUG","name":"http.request","timestamp":"2026-03-01T19:38:32.602385+03:00","duration":195040541,"request.remoteAddr":"127.0.0.1:60449","tokens.type":"bearer","request.method":"GET","request.status":301,"serviceName":"http server"}
```

## Changes

- Modified `log/event.go`: `toAttrs()` method now conditionally appends `steps` and `errors` attributes only when they contain data

## Testing & Validation

- All existing tests pass (`task test`)
- Linter passes with 0 issues (`task lint`)
- No race conditions detected

## Code Review Summary

**Blockers**: None (P0/P1)
**Findings**: No material issues identified
**Risk**: Minor - downstream log parsers may need to handle missing fields instead of empty arrays

## Breaking Changes

Log entries will no longer contain `steps: []` or `errors: []` when empty. Systems parsing these logs should be updated to handle missing keys.