### PR TITLE
Handle closed processor job channels

### DIFF
--- a/queue/processor.go
+++ b/queue/processor.go
@@ -108,7 +108,12 @@ func (p *Processor[T]) worker(ctx context.Context) {
 			breakLoop = true
 		default:
 			select {
-			case job := <-jobChan:
+			case job, ok := <-jobChan:
+				if !ok {
+					log.InfoContext(ctx, "job channel closed")
+					return
+				}
+
 				p.handler.Handle(ctx, job)
 
 			case <-ctx.Done():
@@ -136,7 +141,12 @@ func (p *Processor[T]) worker(ctx context.Context) {
 			return
 		default:
 			select {
-			case job := <-jobChan:
+			case job, ok := <-jobChan:
+				if !ok {
+					log.InfoContext(shutdownCtx, "job channel closed")
+					return
+				}
+
 				p.handler.Handle(shutdownCtx, job)
 			case <-shutdownCtx.Done():
 				log.InfoContext(shutdownCtx, "shutdown timeout expired")

--- a/queue/processor_test.go
+++ b/queue/processor_test.go
@@ -67,6 +67,51 @@ func TestProcessor(t *testing.T) {
 		}
 	})
 
+	t.Run("closed provider", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		jobChan := make(chan job, 2)
+		jobChan <- job{data: 1}
+		jobChan <- job{data: 2}
+		close(jobChan)
+
+		q := &mockQueue[job]{jobChan: jobChan}
+		var handled atomic.Int32
+		var result atomic.Int32
+
+		p := queue.New(queue.HandlerFunc[job](func(_ context.Context, job job) {
+			handled.Add(1)
+			result.Add(int32(job.data))
+		}), q, 4, time.Millisecond)
+
+		runResult := make(chan error, 1)
+		go func() {
+			runResult <- p.Run(ctx)
+		}()
+
+		select {
+		case err := <-runResult:
+			if err != nil {
+				t.Fatalf("expected no error, got: %s", err.Error())
+			}
+		case <-time.After(time.Second):
+			cancel()
+			<-runResult
+			t.Fatal("expected processor to stop after provider closed job channel")
+		}
+
+		if handled.Load() != 2 {
+			t.Fatalf("expected 2 handled jobs, got %d", handled.Load())
+		}
+
+		if result.Load() != 3 {
+			t.Fatalf("expected result to be 3, got %d", result.Load())
+		}
+	})
+
 	t.Run("run fail", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## What changed

- check the receive `ok` flag in both processor worker receive loops
- stop workers when the provider job channel reaches end-of-stream
- add a regression test covering buffered jobs followed by provider channel closure

## Why

Receiving from a closed provider channel previously returned zero-value jobs forever. Workers repeatedly passed those jobs to the handler, which could corrupt data and prevented the processor from stopping normally.

The processor now models channel closure as end-of-stream, while still processing jobs buffered before the channel was closed.

## Validation

- `task check`
- race-enabled repository test suite
- golangci-lint (0 issues)
