### PR TITLE
Fix concurrent health state snapshots

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"time"
 
 	"github.com/platforma-dev/platforma/database"
 	"github.com/platforma-dev/platforma/log"
@@ -49,9 +48,12 @@ func New() *Application {
 // Health returns the current health status of the application.
 func (a *Application) Health(ctx context.Context) *Health {
 	for hcName, hc := range a.healthcheckers {
-		a.health.SetServiceData(hcName, hc.Healthcheck(ctx))
+		if err := a.health.SetServiceData(hcName, hc.Healthcheck(ctx)); err != nil {
+			log.ErrorContext(ctx, "failed to set service health data", "service", hcName, "error", err)
+		}
 	}
-	return a.health
+
+	return a.health.Snapshot()
 }
 
 // OnStart registers a new startup task with the given runner and configuration.
@@ -78,7 +80,7 @@ func (a *Application) RegisterRepository(dbName string, repoName string, reposit
 func (a *Application) RegisterService(serviceName string, service Runner) {
 
 	a.services[serviceName] = service
-	a.health.Services[serviceName] = &ServiceHealth{Status: ServiceStatusNotStarted}
+	a.health.RegisterService(serviceName)
 
 	healthcheckerService, ok := service.(Healthchecker)
 	if ok {
@@ -167,7 +169,7 @@ func (a *Application) run(ctx context.Context) error {
 		}()
 	}
 
-	a.health.StartedAt = time.Now()
+	a.health.StartApplication()
 
 	wg.Wait()
 

--- a/application/health.go
+++ b/application/health.go
@@ -1,7 +1,10 @@
 package application
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"time"
 )
 
@@ -30,6 +33,8 @@ type ServiceHealth struct {
 type Health struct {
 	StartedAt time.Time                 `json:"startedAt"`
 	Services  map[string]*ServiceHealth `json:"services"`
+
+	mu sync.RWMutex
 }
 
 // NewHealth creates an ApplicationHealth with initialized storage.
@@ -37,20 +42,32 @@ func NewHealth() *Health {
 	return &Health{Services: make(map[string]*ServiceHealth)}
 }
 
+// RegisterService adds a service with its initial health status.
+func (h *Health) RegisterService(serviceName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.Services[serviceName] = &ServiceHealth{Status: ServiceStatusNotStarted}
+}
+
 // StartService marks the given service as started and stores start time.
 func (h *Health) StartService(serviceName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if service, ok := h.Services[serviceName]; ok {
 		service.Status = ServiceStatusStarted
 
 		st := time.Now()
 		service.StartedAt = &st
-
-		h.Services[serviceName] = service
 	}
 }
 
 // FailService marks the given service as failed and stores the error.
 func (h *Health) FailService(serviceName string, err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if service, ok := h.Services[serviceName]; ok {
 		service.Status = ServiceStatusError
 
@@ -58,25 +75,110 @@ func (h *Health) FailService(serviceName string, err error) {
 		service.StoppedAt = &st
 
 		service.Error = err.Error()
-
-		h.Services[serviceName] = service
 	}
 }
 
-// SetServiceData stores additional health payload for the given service.
-func (h *Health) SetServiceData(serviceName string, data any) {
-	if service, ok := h.Services[serviceName]; ok {
-		service.Data = data
-		h.Services[serviceName] = service
+// SetServiceData stores an owned, JSON-serialized copy of a service health payload.
+// The caller must not mutate data until SetServiceData returns, but retains ownership
+// and may safely mutate it afterward.
+func (h *Health) SetServiceData(serviceName string, data any) error {
+	var dataSnapshot json.RawMessage
+	var serializeErr error
+	if data != nil {
+		dataSnapshot, serializeErr = serializeServiceData(data)
 	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	service, ok := h.Services[serviceName]
+	if !ok {
+		return nil
+	}
+	if data == nil {
+		service.Data = nil
+
+		return nil
+	}
+	if serializeErr != nil {
+		return fmt.Errorf("serialize health data for service %q: %w", serviceName, serializeErr)
+	}
+
+	service.Data = dataSnapshot
+
+	return nil
+}
+
+// Snapshot returns a detached copy of the current health state.
+func (h *Health) Snapshot() *Health {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	services := make(map[string]*ServiceHealth, len(h.Services))
+	for serviceName, service := range h.Services {
+		services[serviceName] = snapshotServiceHealth(service)
+	}
+
+	return &Health{
+		StartedAt: h.StartedAt,
+		Services:  services,
+	}
+}
+
+func snapshotServiceHealth(service *ServiceHealth) *ServiceHealth {
+	if service == nil {
+		return nil
+	}
+
+	snapshot := *service
+	snapshot.StartedAt = snapshotTime(service.StartedAt)
+	snapshot.StoppedAt = snapshotTime(service.StoppedAt)
+	snapshot.Data = snapshotServiceData(service.Data)
+
+	return &snapshot
+}
+
+func serializeServiceData(data any) (json.RawMessage, error) {
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal health data: %w", err)
+	}
+
+	return json.RawMessage(serialized), nil
+}
+
+func snapshotServiceData(data any) any {
+	if data == nil {
+		return nil
+	}
+
+	serialized, ok := data.(json.RawMessage)
+	if !ok {
+		return nil
+	}
+
+	return json.RawMessage(bytes.Clone(serialized))
+}
+
+func snapshotTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	snapshot := *value
+
+	return &snapshot
 }
 
 func (h *Health) String() string {
-	b, _ := json.Marshal(h)
+	b, _ := json.Marshal(h.Snapshot())
 	return string(b)
 }
 
 // StartApplication marks application start time.
 func (h *Health) StartApplication() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	h.StartedAt = time.Now()
 }

--- a/application/health_test.go
+++ b/application/health_test.go
@@ -1,0 +1,265 @@
+package application_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/platforma-dev/platforma/application"
+)
+
+func TestHealthSnapshotIsDetached(t *testing.T) {
+	t.Parallel()
+
+	health := application.NewHealth()
+	health.RegisterService("worker")
+	health.StartApplication()
+	health.StartService("worker")
+	payload := map[string][]string{"queues": {"default"}}
+	if err := health.SetServiceData("worker", payload); err != nil {
+		t.Fatalf("set service data: %v", err)
+	}
+	payload["queues"][0] = "mutated after storage"
+
+	snapshot := health.Snapshot()
+	serviceSnapshot := snapshot.Services["worker"]
+	if serviceSnapshot == nil || serviceSnapshot.StartedAt == nil {
+		t.Fatal("expected started service in snapshot")
+	}
+
+	snapshot.StartedAt = time.Time{}
+	*serviceSnapshot.StartedAt = time.Time{}
+	serviceSnapshot.Status = application.ServiceStatusError
+	dataSnapshot, ok := serviceSnapshot.Data.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected serialized service data, got %T", serviceSnapshot.Data)
+	}
+	dataSnapshot[0] = 'x'
+	delete(snapshot.Services, "worker")
+
+	freshSnapshot := health.Snapshot()
+	freshService := freshSnapshot.Services["worker"]
+	if freshSnapshot.StartedAt.IsZero() {
+		t.Fatal("mutating snapshot changed application start time")
+	}
+	if freshService == nil {
+		t.Fatal("mutating snapshot changed service map")
+	}
+	if freshService.Status != application.ServiceStatusStarted {
+		t.Fatalf("expected service status %q, got %q", application.ServiceStatusStarted, freshService.Status)
+	}
+	if freshService.StartedAt == nil || freshService.StartedAt.IsZero() {
+		t.Fatal("mutating snapshot changed service start time")
+	}
+
+	var freshPayload map[string][]string
+	freshData, ok := freshService.Data.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected serialized fresh service data, got %T", freshService.Data)
+	}
+	if err := json.Unmarshal(freshData, &freshPayload); err != nil {
+		t.Fatalf("decode fresh service data: %v", err)
+	}
+	if freshPayload["queues"][0] != "default" {
+		t.Fatalf("expected detached service data, got %q", freshPayload["queues"][0])
+	}
+}
+
+func TestHealthRejectsNonJSONServiceData(t *testing.T) {
+	t.Parallel()
+
+	health := application.NewHealth()
+	health.RegisterService("worker")
+
+	err := health.SetServiceData("worker", make(chan struct{}))
+	if err == nil {
+		t.Fatal("expected non-JSON service data to be rejected")
+	}
+
+	if health.Snapshot().Services["worker"].Data != nil {
+		t.Fatal("rejected service data was stored")
+	}
+}
+
+func TestSetServiceDataUnknownServiceIsNoop(t *testing.T) {
+	t.Parallel()
+
+	health := application.NewHealth()
+
+	if err := health.SetServiceData("unknown", make(chan struct{})); err != nil {
+		t.Fatalf("expected unknown service to remain a no-op, got: %v", err)
+	}
+}
+
+func TestSetServiceDataAllowsReentrantJSONMarshaler(t *testing.T) {
+	t.Parallel()
+
+	health := application.NewHealth()
+	health.RegisterService("worker")
+
+	result := make(chan error, 1)
+	go func() {
+		result <- health.SetServiceData("worker", reentrantHealthPayload{health: health})
+	}()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("set reentrant service data: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SetServiceData deadlocked while marshaling reentrant payload")
+	}
+}
+
+func TestHealthConcurrentUpdatesAndSnapshots(t *testing.T) {
+	t.Parallel()
+
+	const (
+		goroutineCount = 8
+		iterationCount = 500
+	)
+
+	health := application.NewHealth()
+	health.RegisterService("worker")
+
+	serviceErr := errors.New("service failed")
+	start := make(chan struct{})
+	errs := make(chan error, goroutineCount)
+
+	var wg sync.WaitGroup
+	for goroutineIndex := range goroutineCount {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for iterationIndex := range iterationCount {
+				if goroutineIndex%2 == 0 {
+					health.RegisterService("auxiliary")
+					health.StartApplication()
+					health.StartService("worker")
+					payload := map[string][]int{"iterations": {iterationIndex}}
+					if err := health.SetServiceData("worker", payload); err != nil {
+						errs <- fmt.Errorf("set service data: %w", err)
+
+						return
+					}
+					payload["iterations"][0] = -1
+					health.FailService("worker", serviceErr)
+
+					continue
+				}
+
+				snapshot := health.Snapshot()
+				if _, err := json.Marshal(snapshot); err != nil {
+					errs <- fmt.Errorf("marshal health snapshot: %w", err)
+
+					return
+				}
+
+				_ = health.String()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestHealthCheckHandlerConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	const (
+		goroutineCount = 8
+		requestCount   = 200
+	)
+
+	service := &healthcheckService{}
+	app := application.New()
+	app.RegisterService("worker", service)
+	handler := application.NewHealthCheckHandler(app)
+
+	start := make(chan struct{})
+	errs := make(chan error, goroutineCount)
+
+	var wg sync.WaitGroup
+	for range goroutineCount {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for range requestCount {
+				response := httptest.NewRecorder()
+				request := httptest.NewRequest(http.MethodGet, "/health", nil)
+				handler.ServeHTTP(response, request)
+
+				if response.Code != http.StatusOK {
+					errs <- fmt.Errorf("expected status %d, got %d", http.StatusOK, response.Code)
+
+					return
+				}
+
+				var snapshot application.Health
+				if err := json.Unmarshal(response.Body.Bytes(), &snapshot); err != nil {
+					errs <- fmt.Errorf("decode health response: %w", err)
+
+					return
+				}
+
+				if snapshot.Services["worker"] == nil {
+					errs <- errors.New("health response is missing worker service")
+
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+type healthcheckService struct {
+	checkCount atomic.Int64
+}
+
+type reentrantHealthPayload struct {
+	health *application.Health
+}
+
+func (p reentrantHealthPayload) MarshalJSON() ([]byte, error) {
+	_ = p.health.Snapshot()
+
+	return []byte(`{"reentrant":true}`), nil
+}
+
+func (s *healthcheckService) Run(context.Context) error {
+	return nil
+}
+
+func (s *healthcheckService) Healthcheck(context.Context) any {
+	return struct {
+		Check int64 `json:"check"`
+	}{Check: s.checkCount.Add(1)}
+}

--- a/application/healthcheck.go
+++ b/application/healthcheck.go
@@ -23,9 +23,9 @@ func NewHealthCheckHandler(app healther) *HealthCheckHandler {
 }
 
 func (h *HealthCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	health := h.app.Health(r.Context())
+	healthSnapshot := h.app.Health(r.Context())
 
-	if err := httpserver.WriteJSON(w, http.StatusOK, health); err != nil {
+	if err := httpserver.WriteJSON(w, http.StatusOK, healthSnapshot); err != nil {
 		log.ErrorContext(r.Context(), "failed to write health response", "error", err)
 	}
 }

--- a/application/healthchecker.go
+++ b/application/healthchecker.go
@@ -4,6 +4,7 @@ import "context"
 
 // Healthchecker represents a service that can perform health checks.
 type Healthchecker interface {
-	// Healthcheck returns the health status of the service.
+	// Healthcheck returns JSON-serializable health data for the service.
+	// The returned value must not be mutated after Healthcheck returns.
 	Healthcheck(context.Context) any
 }


### PR DESCRIPTION
## Summary

- synchronize all application health-state mutations
- return detached snapshots for health responses instead of exposing live maps and records
- serialize health-check payloads into owned JSON bytes outside the health lock
- clone payload bytes and timestamp pointers in every snapshot
- document the health-check payload ownership contract

## Root cause

Service lifecycle goroutines updated the live health map and service records while HTTP requests encoded the same objects. Payloads stored in `Data` could also alias caller-owned maps, slices, or pointers. Serializing user payloads under the health lock would avoid aliasing but could deadlock through re-entrant `MarshalJSON` implementations and block lifecycle transitions.

## Impact

Health requests now observe stable, detached snapshots. Producers may mutate payloads after `SetServiceData` returns without racing response serialization, and custom JSON marshalers execute without holding the health-state lock.

## Validation

- `go test -race ./application`
- `go test -race ./...`
- `task lint`
